### PR TITLE
Init commit test compiled release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Build and release plugin
+
+# Fires on a version tag push, e.g.:
+#   git tag 2.0.5 && git push origin 2.0.5
+#
+# Builds the CSS/JS assets, zips the plugin (compiled assets included,
+# dev-only files stripped out) and attaches the zip to a GitHub Release
+# for that tag. See README.md for how to pull the release zip with Composer.
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build assets
+        run: npm run build
+
+      - name: Verify built asset handles
+        run: npm run verify:assets
+
+      - name: Check plugin version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME}"
+          PLUGIN_VERSION=$(grep -m1 -oP 'Version:\s*\K[0-9.]+' website-builder-blocks.php)
+          if [ "$TAG_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "Tag ($TAG_VERSION) does not match the Version header in website-builder-blocks.php ($PLUGIN_VERSION)." >&2
+            exit 1
+          fi
+
+      - name: Assemble release package
+        run: |
+          PKG_DIR="dist/website-builder-blocks"
+          mkdir -p "$PKG_DIR"
+          cp -R build assets languages src "$PKG_DIR/"
+          cp website-builder-blocks.php composer.json README.md "$PKG_DIR/"
+          (cd dist && zip -r "../website-builder-blocks-${GITHUB_REF_NAME}.zip" website-builder-blocks)
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: website-builder-blocks-${{ github.ref_name }}.zip
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -16,6 +16,45 @@ Raise issues via
 ## Installation
 Download this repository, unzip and copy the folder into your WordPress plugin file directory.
 
+### Installing via Composer
+
+Each version tag (`X.Y.Z`, matching the `Version:` header in
+`website-builder-blocks.php`) triggers a
+[GitHub Action](.github/workflows/release.yml) that compiles the CSS/JS
+assets and attaches a ready-to-use plugin zip to the matching
+[GitHub release](https://github.com/ministryofjustice/website-builder-blocks/releases).
+
+To pull a release with Composer, add a `package` repository pointing at the
+release asset and require it, e.g. for version `2.0.4`:
+
+```json
+{
+  "repositories": [
+    {
+      "type": "package",
+      "package": {
+        "name": "ministryofjustice/website-builder-blocks",
+        "version": "2.0.4",
+        "type": "wordpress-plugin",
+        "dist": {
+          "url": "https://github.com/ministryofjustice/website-builder-blocks/releases/download/2.0.4/website-builder-blocks-2.0.4.zip",
+          "type": "zip"
+        }
+      }
+    }
+  ],
+  "require": {
+    "ministryofjustice/website-builder-blocks": "2.0.4"
+  }
+}
+```
+
+Bump both the `version` and the `dist.url` (and the `require` constraint)
+whenever you pull a newer release. This requires
+[`composer/installers`](https://packagist.org/packages/composer/installers)
+(or an equivalent `installer-paths` config) to place `wordpress-plugin`
+packages into `wp-content/plugins/`.
+
 ## Prerequesites
 * NPM (For developers needing to compile assets)
 

--- a/website-builder-blocks.php
+++ b/website-builder-blocks.php
@@ -6,7 +6,7 @@
  * Plugin name: Website Builder Blocks
  * Plugin URI:  https://github.com/ministryofjustice/website-builder-blocks
  * Description: Introduces new Wordpress blocks
- * Version:     2.0.4
+ * Version:     2.0.5
  * Author:      Ministry of Justice
  * Text domain: wb_blocks
  * Domain Path: /languages


### PR DESCRIPTION
Add a GitHub Actions workflow that automates plugin releases. On every version-tag push (X.Y.Z), it compiles the CSS/JS assets, verifies the build, checks the tag matches the plugin's Version: header, then zips the plugin with its compiled assets (dev-only files stripped) and attaches it to a GitHub Release. This lets the plugin be pulled as a ready-to-use package via Composer without needing to build assets locally. The README now documents the Composer package-repository snippet for installing a given release.