### PR TITLE
Table of contents HTML fix

### DIFF
--- a/src/custom-blocks/table-of-contents/inc/functions.php
+++ b/src/custom-blocks/table-of-contents/inc/functions.php
@@ -69,7 +69,14 @@
 		}
 	
 		// This is the content with IDs for all h2 elements (or whatever was set in $tags)
-		$changed_content = trim($dom->saveHtml());
+		$body = $dom->getElementsByTagName('body')->item(0);
+
+		$changed_content = "";
+		foreach ($body->childNodes as $child) {
+			$changed_content .= $dom->saveHTML($child);
+		}
+
+		$changed_content = trim($changed_content);
 
 		return array("index"=>$index,"content"=>$changed_content);
 	}

--- a/website-builder-blocks.php
+++ b/website-builder-blocks.php
@@ -6,7 +6,7 @@
  * Plugin name: Website Builder Blocks
  * Plugin URI:  https://github.com/ministryofjustice/website-builder-blocks
  * Description: Introduces new Wordpress blocks
- * Version:     2.1.2
+ * Version:     2.1.3
  * Author:      Ministry of Justice
  * Text domain: wb_blocks
  * Domain Path: /languages


### PR DESCRIPTION
Fix for the bug where a whole HMTL page including doctype and html/body tags were added for the table of contents.  